### PR TITLE
userializer: Implement a CompositeSerializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,33 @@ different situations:
 }
 ```
 
+### CompositeSerializer
+
+Imagine you have a compound of different data that you want to return to the same payload.
+For example, you have an **array** of a `Foo` class and a `Bar` value to return.
+You can use a `CompositeSerializer` to serialize both.
+
+```ruby
+array_foo = [Foo.new, Foo.new]
+bar = Bar.new
+
+CompositeSerializer.new(
+  { key_foo: array_foo, key_bar: bar },
+  each_serializer: { key_foo: FooCustomSerializer },
+  serializer: { key_bar: BarSerializer },
+  root: { key_foo: :foo_root, key_bar: :bar_root }
+).to_json
+```
+
+this will render:
+
+```json
+{
+  "foo_root": [{... foo1 attributes ...}, {... foo2 attributes ...}],
+  "bar_root": {... bar attributes ...}
+}
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/userializer.rb
+++ b/lib/userializer.rb
@@ -1,6 +1,7 @@
 require 'userializer/version'
 require 'userializer/base_serializer'
 require 'userializer/array_serializer'
+require 'userializer/composite_serializer'
 
 module USerializer
   NS_SEPARATOR = '::'.freeze

--- a/lib/userializer/composite_serializer.rb
+++ b/lib/userializer/composite_serializer.rb
@@ -1,0 +1,78 @@
+require 'oj'
+
+module USerializer
+  class CompositeObject
+    def initialize(obj, opts = {})
+      @obj = obj
+      @opts = opts
+      @root_key = opts[:root].to_sym
+      serializer = opts[:serializer]
+      @serializer = if serializer.is_a?(Proc)
+                      serializer
+                    elsif serializer
+                      proc { serializer }
+                    end
+    end
+
+    def merge_root(res, opts)
+      serializer(@obj, opts).merge_root(res, @root_key, true, opts)
+    end
+
+    private
+
+    def serializer(obj, opts)
+      return @serializer.call(obj, opts).new(obj, @opts) if @serializer
+      return obj.serialize if obj.respond_to?(:serialize)
+
+      USerializer.infered_serializer_class(obj.class).new(obj, @opts)
+    end
+  end
+
+  class CompositeSerializer
+    def initialize(objs, opts = {})
+      @opts = opts
+      @objs = compose_objs(objs)
+    end
+
+    def merge_root(res, opts)
+      @objs.each do |obj|
+        obj.merge_root(res, opts)
+      end
+    end
+
+    def to_hash
+      res = {}
+
+      merge_root(res, @opts)
+      res
+    end
+
+    def serialize(*_args)
+      to_hash
+    end
+
+    def to_json(*_args)
+      Oj.dump(to_hash, mode: :compat)
+    end
+
+    private
+
+    def compose_objs(objs)
+      objs.map do |(key, obj)|
+        opts = options_for(key)
+
+        if obj.is_a? Enumerable
+          ArraySerializer.new(obj, opts)
+        else
+          CompositeObject.new(obj, opts)
+        end
+      end
+    end
+
+    def options_for(key)
+      @opts.reduce({}) do |acc, (opt_key, values)|
+        acc.merge(opt_key.to_sym => values[key.to_sym])
+      end.compact.merge(root: key) { |_, x, y| x || y }
+    end
+  end
+end

--- a/spec/userializer/composite_serializer_spec.rb
+++ b/spec/userializer/composite_serializer_spec.rb
@@ -1,0 +1,123 @@
+require 'spec_helper'
+
+module CompositeTesting
+  class FooSerializer < USerializer::BaseSerializer
+    attributes :bar
+  end
+
+  class FooSubSerializer < FooSerializer
+    has_many :bazs
+  end
+
+  class FooCustomSerializer < USerializer::BaseSerializer
+    attributes :bar do |object|
+      "custom #{object.bar}"
+    end
+  end
+
+  class Foo
+    attr_accessor :id, :bar, :bazs
+  end
+end
+
+RSpec.describe USerializer::CompositeSerializer do
+  let(:foo) do
+    foo = CompositeTesting::Foo.new
+    foo.id = 1
+    foo.bar = 'bar'
+
+    foo
+  end
+
+  context 'serialize array value' do
+    it do
+      expect(
+        USerializer::CompositeSerializer.new({ key: [foo] }).to_hash
+      ).to eq(key: [{ id: 1, bar: 'bar' }])
+    end
+
+    context 'custom options' do
+      it do
+        expect(
+          USerializer::CompositeSerializer.new(
+            { key: [foo] },
+            each_serializer: { key: CompositeTesting::FooCustomSerializer },
+            root:            { key: :foofoo }
+          ).to_hash
+        ).to eq(foofoo: [{ id: 1, bar: 'custom bar' }])
+      end
+    end
+  end
+
+  context 'serialize single value' do
+    it do
+      expect(
+        USerializer::CompositeSerializer.new({ key: foo }).to_hash
+      ).to eq(key: { id: 1, bar: 'bar' })
+    end
+
+    context 'custom options' do
+      it do
+        expect(
+          USerializer::CompositeSerializer.new(
+            { key: foo },
+            serializer: { key: CompositeTesting::FooCustomSerializer },
+            root:       { key: :foofoo }
+          ).to_hash
+        ).to eq(foofoo: { id: 1, bar: 'custom bar' })
+      end
+    end
+  end
+
+  context 'multi objects' do
+    it do
+      expect(
+        USerializer::CompositeSerializer.new(
+          { key: foo, key_1: [foo] }
+        ).to_hash
+      ).to eq(
+        key:  { id: 1, bar: 'bar' },
+        key_1: [{ id: 1, bar: 'bar' }]
+      )
+    end
+
+    context 'custom options' do
+      it do
+        expect(
+          USerializer::CompositeSerializer.new(
+            { key: foo, key_1: [foo] },
+            each_serializer: { key_1: CompositeTesting::FooCustomSerializer },
+            root:            { key_1: :foooos, key: :foofoo }
+          ).to_hash
+        ).to eq(
+          foofoo: { id: 1, bar: 'bar' },
+          foooos: [{ id: 1, bar: 'custom bar' }]
+        )
+      end
+    end
+  end
+
+  context 'with relations' do
+    before do
+      f_sub = CompositeTesting::Foo.new
+      f_sub.id = 3
+      f_sub.bar = 'sub_bar'
+
+      foo.bazs = [f_sub]
+    end
+
+    it do
+      expect(
+        USerializer::CompositeSerializer.new(
+          { key: foo },
+          serializer: { key: CompositeTesting::FooSubSerializer }
+        ).to_hash
+      ).to(
+        eq(
+          key:  { id: 1, bar: 'bar', baz_ids: [3] },
+          foos: [{ id: 3, bar: 'sub_bar' }]
+        )
+      )
+    end
+  end
+end


### PR DESCRIPTION
### What does this PR do?

Imagine you have a compound of different data that you want to return to the same payload.
For example, you have an **array** of a `Foo` class and a `Bar` value to return.
You can use a `CompositeSerializer` to serialize both.

```ruby
array_foo = [Foo.new, Foo.new]
bar = Bar.new

CompositeSerializer.new(
  { key_foo: array_foo, key_bar: bar },
  each_serializer: { key_foo: FooCustomSerializer },
  serializer: { key_bar: BarSerializer },
  root: { key_foo: :foo_root, key_bar: :bar_root }
).to_json
```

this will render:

```json
{
  "foo_root": [{... foo1 attributes ...}, {... foo2 attributes ...}],
  "bar_root": {... bar attributes ...}
}
```