### PR TITLE
has_(one|many): Allow id key cutomisable

### DIFF
--- a/lib/userializer/has_many.rb
+++ b/lib/userializer/has_many.rb
@@ -6,7 +6,7 @@ module USerializer
       @key = key
 
       @opts = opts
-      @id_key = "#{ActiveSupport::Inflector.singularize(key)}_ids".to_sym
+      @ids_key = opts[:ids_key] || build_ids_key(key)
 
       @embed_key = opts[:embed_key] || :id
       @conditional_block = opts[:if] || proc { true }
@@ -15,7 +15,7 @@ module USerializer
     def merge_attributes(res, ser, opts)
       return unless @conditional_block.call(ser.object, opts)
 
-      res[@id_key] = (entities(ser) || []).compact.map do |obj|
+      res[@ids_key] = (entities(ser) || []).compact.map do |obj|
         obj.nil? ? nil : obj.send(@embed_key)
       end.compact
     end
@@ -33,6 +33,12 @@ module USerializer
       return obj unless @opts[:scope]
 
       obj.send(@opts[:scope])
+    end
+
+    private
+
+    def build_ids_key(key)
+      "#{ActiveSupport::Inflector.singularize(key)}_ids".to_sym
     end
   end
 end

--- a/lib/userializer/has_one.rb
+++ b/lib/userializer/has_one.rb
@@ -3,7 +3,7 @@ module USerializer
     def initialize(key, opts)
       @key = key
       @opts = opts
-      @id_key = "#{key}_id".to_sym
+      @id_key = opts[:id_key] || "#{key}_id".to_sym
       @root_key = opts[:root]&.to_sym
 
       serializer = opts[:serializer]

--- a/spec/userializer/has_one_spec.rb
+++ b/spec/userializer/has_one_spec.rb
@@ -49,6 +49,10 @@ module HasOneTesting
     has_one :foo, serializer: FooSerializer, embed_key: :biz
   end
 
+  class BarIDKeySerializer< USerializer::BaseSerializer
+    has_one :foo, serializer: FooSerializer, id_key: :foobar_id
+  end
+
   class Biz
     attr_accessor :id
   end
@@ -114,6 +118,14 @@ RSpec.describe USerializer::BaseSerializer do
     it do
       expect(HasOneTesting::BarEmbedKeySerializer.new(b).to_hash).to eq(
         bar: { id: 2, foo_id: 'buz' }, foos: [{ bar: 'bar', id: 1 }]
+      )
+    end
+  end
+
+  context 'id_key' do
+    it do
+      expect(HasOneTesting::BarIDKeySerializer.new(b).to_hash).to eq(
+        bar: { id: 2, foobar_id: 1 }, foos: [{ bar: 'bar', id: 1 }]
       )
     end
   end


### PR DESCRIPTION
The idea before this is to be able to customizable the key name of the field that will handle the relation IDs in the parent model.

Another way would be to use the `root_key` of the serializer of the collection, this involves more modifications. 