### PR TITLE
base_serializer: Add the "only" option

### DIFF
--- a/lib/userializer/base_serializer.rb
+++ b/lib/userializer/base_serializer.rb
@@ -112,7 +112,7 @@ module USerializer
     end
 
     def allow?(key)
-      return @only.include?(key) unless @only.empty?
+      return @only.include?(key) if @only.any?
       !@except.include?(key)
     end
   end

--- a/lib/userializer/base_serializer.rb
+++ b/lib/userializer/base_serializer.rb
@@ -45,6 +45,7 @@ module USerializer
       @opts = opts
       @meta = opts[:meta]
       @except = Set.new([opts[:except]].flatten.compact)
+      @only = Set.new([opts[:only]].flatten.compact)
 
       @root_key = (opts[:root] || ActiveSupport::Inflector.underscore(
         obj.class.name
@@ -99,15 +100,20 @@ module USerializer
     private
 
     def attributes
-      @attributes ||= (self.class.attrs || {}).values.reject do |attr|
-        @except.include?(attr.key)
+      @attributes ||= (self.class.attrs || {}).values.select do |attr|
+        allow?(attr.key)
       end
     end
 
     def relations
-      @relations ||= (self.class.relations || {}).values.reject do |rel|
-        @except.include?(rel.key)
+      @relations ||= (self.class.relations || {}).values.select do |rel|
+        allow?(rel.key)
       end
+    end
+
+    def allow?(key)
+      return @only.include?(key) unless @only.empty?
+      !@except.include?(key)
     end
   end
 end

--- a/spec/userializer/basic_serialization_spec.rb
+++ b/spec/userializer/basic_serialization_spec.rb
@@ -86,4 +86,20 @@ RSpec.describe USerializer::BaseSerializer do
       )
     end
   end
+
+  context 'only' do
+    it do
+      expect(FooSerializer.new(f, only: %i[buz]).to_hash).to eq(
+        foo: { buz: 'biz' }
+      )
+    end
+  end
+
+  context 'only && except' do
+    it do
+      expect(FooSerializer.new(
+        f, only: %i[buz], except: %i[buz]
+      ).to_hash).to eq(foo: { buz: 'biz' })
+    end
+  end
 end


### PR DESCRIPTION
### What does this PR do?

This PR adds the option `only` which allow us to select only the fields we want to serialize.

### What are the observable changes?
- Handle the `only` option in the attributes / relations selection.

### Good PR checklist

- [X] Title makes sense
- [X] Is against the correct branch
- [X] Only addresses one issue
- [X] Properly assigned
- [X] Added/updated tests
- [ ] Added/updated documentation
- [ ] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
