### PR TITLE
base_serializer: Rename attributes/relations to avoid conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,5 @@ on:
 jobs:
   test:
     name: Run Tests
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        ruby: [2.7, 3.0.3]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Install Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
-    - name: Run the Test Suite
-      run: bundle exec rspec --color --require spec_helper --format progress spec
+    uses: upfluence/actions/.github/workflows/lib-ruby-test.yml@master
+    secrets: inherit

--- a/lib/userializer/base_serializer.rb
+++ b/lib/userializer/base_serializer.rb
@@ -55,8 +55,8 @@ module USerializer
     def serializable_hash(opts)
       res = {}
 
-      attributes.each { |attr| attr.merge_attributes(res, self, opts) }
-      relations.each do |rel|
+      _attributes.each { |attr| attr.merge_attributes(res, self, opts) }
+      _relations.each do |rel|
         rel.merge_attributes(res, self, opts)
       end
 
@@ -78,7 +78,7 @@ module USerializer
         end
       end
 
-      relations.each { |rel| rel.merge_root(res, self, opts) }
+      _relations.each { |rel| rel.merge_root(res, self, opts) }
     end
 
     def to_hash
@@ -99,14 +99,14 @@ module USerializer
 
     private
 
-    def attributes
-      @attributes ||= (self.class.attrs || {}).values.select do |attr|
+    def _attributes
+      @_attributes ||= (self.class.attrs || {}).values.select do |attr|
         allow?(attr.key)
       end
     end
 
-    def relations
-      @relations ||= (self.class.relations || {}).values.select do |rel|
+    def _relations
+      @_relations ||= (self.class.relations || {}).values.select do |rel|
         allow?(rel.key)
       end
     end

--- a/spec/userializer/basic_serialization_spec.rb
+++ b/spec/userializer/basic_serialization_spec.rb
@@ -25,8 +25,16 @@ class FooSubSerializer < FooSerializer
 end
 
 class FooSkipNilSerializer < USerializer::BaseSerializer
-   attributes :bazs
-   attributes :bar, skip_nil: true
+  attributes :bazs
+  attributes :bar, skip_nil: true
+end
+
+class AttributesRelations
+  attr_accessor :id, :relations, :attributes
+end
+
+class AttributesRelationsSerializer < USerializer::BaseSerializer
+  attributes :relations, :attributes
 end
 
 RSpec.describe USerializer::BaseSerializer do
@@ -118,6 +126,26 @@ RSpec.describe USerializer::BaseSerializer do
     it do
       expect(FooSkipNilSerializer.new(f).to_hash).to eq(
         foo: { id: 1, bazs: nil }
+      )
+    end
+  end
+
+  context 'attributes && relations' do
+    let(:f) do
+      f = AttributesRelations.new
+      f.id = 1
+      f.attributes = 'foo'
+      f.relations = 'bar'
+      f
+    end
+
+    it do
+      expect(AttributesRelationsSerializer.new(f).to_hash).to eq(
+        attributes_relations: {
+          id:         1,
+          attributes: 'foo',
+          relations:  'bar'
+        }
       )
     end
   end


### PR DESCRIPTION
### What does this PR do?

Rename private method `attributes` to `_attributes` and `relations` to `_relations` to avoid conflict
### Good PR checklist

- [X] Title makes sense
- [X] Is against the correct branch
- [X] Only addresses one issue
- [X] Properly assigned
- [X] Added/updated tests
- [ ] Added/updated documentation
- [ ] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
